### PR TITLE
removed fixed location selection

### DIFF
--- a/.ci/hcloud-centos-8/cluster.yaml
+++ b/.ci/hcloud-centos-8/cluster.yaml
@@ -8,7 +8,6 @@ metadata:
 domain: stackable.test
 publicKeys: []
 spec:
-  location: "hel1"
   k8sVersion: "$K8S_VERSION"
   wireguard: false
   versions:


### PR DESCRIPTION
Removed `location` attribute in the cluster definition. In this case, T2 will leave it up to HCloud to select a location with free resources.